### PR TITLE
Add documentation index and architecture docs (database, classes, API)

### DIFF
--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -1,0 +1,45 @@
+# REST API Reference
+
+## Scope
+
+This document lists REST API endpoints discovered in the repository. The current repository contains a profile README and static assets only. No web application framework, route declarations, controllers, OpenAPI specification, Postman collection, or REST API implementation was found.
+
+## Endpoint Inventory
+
+No REST API endpoints are currently implemented.
+
+| Method | Path | Parameters | Request Body | Response | Description |
+| --- | --- | --- | --- | --- | --- |
+| _None found_ | _None found_ | Not applicable | Not applicable | Not applicable | The repository currently has no REST API source code or specification. |
+
+## Authentication and Authorization
+
+No API authentication or authorization mechanism is currently defined because no API is implemented.
+
+## Error Handling
+
+No API error response format is currently defined because no API is implemented.
+
+## Versioning
+
+No API versioning strategy is currently defined because no API is implemented.
+
+## Recommendations for Future API Documentation
+
+If REST API code is added later, update this document with:
+
+1. Every endpoint method and path.
+2. Path, query, header, and body parameters.
+3. Authentication and authorization requirements.
+4. Request and response examples.
+5. Status codes and error response schemas.
+6. Links to controller or route source files.
+7. Links to any OpenAPI, Swagger, Postman, or contract-testing artifacts.
+
+## Suggested Endpoint Documentation Template
+
+Use the following format for future endpoints:
+
+| Method | Path | Parameters | Request Body | Response | Description |
+| --- | --- | --- | --- | --- | --- |
+| `GET` | `/api/example/{id}` | `id` path parameter | None | `200 OK` with example resource | Retrieves a single example resource. |

--- a/docs/architecture/classes.md
+++ b/docs/architecture/classes.md
@@ -1,0 +1,72 @@
+# Class Architecture
+
+## Scope
+
+This document captures class-level architecture discovered in the repository. The current repository is a GitHub profile/portfolio repository made up of Markdown and static assets. No class-based source code was found.
+
+## Current UML Diagram
+
+The following Mermaid class diagram represents the current repository structure rather than application runtime classes.
+
+```mermaid
+classDiagram
+    class ProfileRepository {
+        +README.md profileContent
+        +docs documentation
+        +staticAssets imagesAndGraphics
+    }
+
+    class ReadmeProfile {
+        +string aboutMe
+        +string certifications
+        +string skillsAndTools
+        +string contactLinks
+        +string brandAssetNotice
+    }
+
+    class StaticAsset {
+        +string fileName
+        +string format
+        +string purpose
+    }
+
+    class DocumentationSet {
+        +index.md documentationIndex
+        +database.md databaseArchitecture
+        +classes.md classArchitecture
+        +api.md restApiReference
+    }
+
+    ProfileRepository "1" o-- "1" ReadmeProfile : contains
+    ProfileRepository "1" o-- "many" StaticAsset : references
+    ProfileRepository "1" o-- "1" DocumentationSet : documents
+```
+
+## Class Inventory
+
+No application classes are currently implemented.
+
+| Class | File | Description | Attributes | Methods | Relationships |
+| --- | --- | --- | --- | --- | --- |
+| _None found_ | Not applicable | No source code classes are present. | Not applicable | Not applicable | Not applicable |
+
+## Repository Structure Concepts
+
+Although no runtime classes exist, the repository can be understood through the following documentation concepts:
+
+| Concept | Description |
+| --- | --- |
+| `ProfileRepository` | The repository as a whole, containing the profile README, documentation, and supporting assets. |
+| `ReadmeProfile` | The main profile page describing professional background, certifications, tooling, and contact channels. |
+| `StaticAsset` | Image and vector files used by the profile README. |
+| `DocumentationSet` | The documentation files under `docs/` that describe the current architecture inventory. |
+
+## Recommendations for Future Class Documentation
+
+If application code is added later, update this document with:
+
+1. All domain, service, controller, repository, model, and utility classes.
+2. Class attributes, public methods, inheritance, composition, aggregation, and dependencies.
+3. Package/module boundaries.
+4. Links from each class entry to source files.
+5. Notes about design patterns, lifecycle, and responsibility boundaries.

--- a/docs/architecture/database.md
+++ b/docs/architecture/database.md
@@ -1,0 +1,64 @@
+# Database Architecture
+
+## Scope
+
+This document describes the database architecture discovered in the repository. The requested target database is PostgreSQL; however, this repository currently does not contain PostgreSQL schema files, migration files, SQL dumps, ORM definitions, or application code that declares database tables.
+
+## PostgreSQL Schema Status
+
+No PostgreSQL schema is currently implemented in the repository.
+
+Searched repository indicators include:
+
+- SQL schema or migration files such as `*.sql`.
+- ORM model files and common migration folders.
+- Application configuration files that typically contain PostgreSQL connection details.
+- Source files that define database entities.
+
+None were present in the current repository snapshot.
+
+## Entity-Relationship Diagram
+
+Because no database tables or relationships are defined, the current ERD contains a single documentation note node.
+
+```mermaid
+erDiagram
+    REPOSITORY_DOCUMENTATION_NOTE {
+        string status "No PostgreSQL schema found"
+        string recommendation "Add migrations or schema definitions before modeling entities"
+    }
+```
+
+## Tables
+
+No PostgreSQL tables are currently defined.
+
+| Table | Description | Fields | Relationships |
+| --- | --- | --- | --- |
+| _None found_ | The repository currently has no database schema. | Not applicable | Not applicable |
+
+## Field Inventory
+
+No table fields are currently available to document.
+
+| Table | Field | Type | Nullable | Default | Description |
+| --- | --- | --- | --- | --- | --- |
+| _None found_ | _None found_ | Not applicable | Not applicable | Not applicable | No PostgreSQL fields are defined in this repository. |
+
+## Index Inventory
+
+No PostgreSQL indexes are currently defined.
+
+| Table | Index | Columns | Type | Description |
+| --- | --- | --- | --- | --- |
+| _None found_ | _None found_ | Not applicable | Not applicable | No indexes are defined because no schema is present. |
+
+## Recommendations for Future Database Documentation
+
+If database-backed application code is added later, update this document with:
+
+1. The canonical schema source, such as migration files or checked-in SQL.
+2. A complete ERD showing primary keys, foreign keys, cardinality, and optionality.
+3. A table-by-table field catalog with data types, nullability, defaults, constraints, and business meaning.
+4. An index catalog including primary keys, unique indexes, foreign-key indexes, partial indexes, and GIN/GiST indexes where applicable.
+5. Any PostgreSQL-specific features such as extensions, enums, views, triggers, stored procedures, row-level security policies, or partitioning.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,24 @@
+# Mitesh411 Documentation
+
+## Project Description
+
+This repository is a GitHub profile and professional portfolio for Mitesh Dandade, a Quality Assurance Engineer and Test Automation Architect. The project is primarily Markdown and static image assets that present certifications, quality engineering skills, automation testing tools, CI/CD capabilities, database technologies, communication tools, browser support, and contact information.
+
+During documentation review, no runnable application source code, PostgreSQL schema migrations, ORM models, database dumps, REST controllers, route declarations, or API specifications were found in the repository. The architecture documents therefore record the current repository state and identify where future implementation details should be added if application code is introduced.
+
+## Documentation Index
+
+- [Database Architecture](./architecture/database.md) — Current database/schema status, ERD placeholder, table inventory, and index inventory.
+- [Class Architecture](./architecture/classes.md) — Current class/model status and UML diagram for the static repository structure.
+- [REST API Reference](./architecture/api.md) — Current REST endpoint inventory and guidance for documenting future endpoints.
+
+## Repository Overview
+
+| Area | Current Contents |
+| --- | --- |
+| Primary content | `README.md` profile/portfolio page |
+| Static assets | PNG, GIF, and SVG assets referenced by the profile page |
+| Application code | Not present |
+| Database schema | Not present |
+| REST API implementation | Not present |
+| Class-based source files | Not present |


### PR DESCRIPTION
### Motivation

- Provide a clear starting point and architecture documentation for the repository, which is primarily a GitHub profile/portfolio with Markdown and static assets. 
- Record the current absence of application code, PostgreSQL schema, classes, and REST APIs while offering templates and guidance for future additions. 

### Description

- Add `docs/index.md` containing a project description, a documentation index, and a repository overview. 
- Add `docs/architecture/database.md` documenting PostgreSQL schema status, a Mermaid ERD placeholder, table/field/index inventories (none present), and recommendations for future schema documentation. 
- Add `docs/architecture/classes.md` with a Mermaid class (UML) diagram representing repository concepts, a class inventory (none present), and guidance for future class documentation. 
- Add `docs/architecture/api.md` noting the absence of REST endpoints, providing an endpoint inventory template, and recommending how to document APIs when implemented. 

### Testing

- Ran repository discovery commands (`rg --files`, `find`) to confirm file inventory and the absence of schema and source code, and these checks succeeded. 
- Performed repository content checks (diff/status) to verify the new documentation files are present in the working tree and this validation succeeded. 
- Checked GitHub CLI authentication (`gh auth status`), which reported no authenticated host so no remote PR was created from this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76140b8ff0832f8f56831631bb8e3e)